### PR TITLE
Explicitly set Python3 for virtualenv on target

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,6 +48,7 @@
     extra_args: "--index-url https://wheels.galaxyproject.org/simple/ --extra-index-url https://pypi.python.org/simple {{ pip_extra_args | default('') }}"
     virtualenv: "{{ tiaas_dir }}/venv/"
     virtualenv_command: "{{ tiaas_virtualenv_command | default(galaxy_virtualenv_command | default(pip_virtualenv_command | default(omit))) }}"
+    virtualenv_python: "{{ tiaas_virtualenv_python | default('python3') }}"
   environment:
     PYTHONPATH: null
     VIRTUAL_ENV: "{{ tiaas_dir }}/venv/"


### PR DESCRIPTION
Reason: Installation of Django 3.x fails on Python2, which may be still the default on the target host.

@hexylena is this a good way to handle this?
