### PR TITLE
Add task to create symlink; refactor; run collectstatic unconditionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Example Playbook
     tiaas_user: tiaas
     tiaas_group: tiaas
     tiaas_version: master
-    tiaas_galaxy_stylesheet: "/[path-to-galaxy-root]/static/style/base.css"
+    tiaas_galaxy_stylesheet: "{{ galaxy_server }}/static/style/base.css"
   roles:
     - natefoo.postgresql_objects
     - usegalaxy-eu.tiaas

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Example Playbook
     tiaas_user: tiaas
     tiaas_group: tiaas
     tiaas_version: master
+    tiaas_galaxy_stylesheet: "/[path-to-galaxy-root]/static/style/base.css"
   roles:
     - natefoo.postgresql_objects
     - usegalaxy-eu.tiaas

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,10 @@ retain_extra_time: 12
 
 # TIaaS Deployment
 tiaas_dir: /opt/tiaas
+tiaas_code_dir: "{{ tiaas_dir }}/code"
+tiaas_config_dir: "{{ tiaas_dir }}/config"
+tiaas_static_dir: "{{ tiaas_dir }}/static"
+tiaas_venv_dir: "{{ tiaas_dir }}/venv"
 tiaas_user: tiaas
 tiaas_group: tiaas
 tiaas_version: master

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,6 +48,7 @@
     extra_args: "--index-url https://wheels.galaxyproject.org/simple/ --extra-index-url https://pypi.python.org/simple {{ pip_extra_args | default('') }}"
     virtualenv: "{{ tiaas_dir }}/venv/"
     virtualenv_command: "{{ tiaas_virtualenv_command | default(galaxy_virtualenv_command | default(pip_virtualenv_command | default(omit))) }}"
+    virtualenv_python: "{{ tiaas_virtualenv_python | default('python3') }}"
   environment:
     PYTHONPATH: null
     VIRTUAL_ENV: "{{ tiaas_dir }}/venv/"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,7 @@
   become_user: "{{ tiaas_user }}"
   git:
     repo: "https://github.com/usegalaxy-eu/tiaas2"
-    dest: "{{ tiaas_dir }}/code/"
+    dest: "{{ tiaas_code_dir }}/"
     version: "{{ tiaas_version }}"
     force: "{{ tiaas_force_checkout }}"
   register: __tiaas_git_update_result
@@ -44,19 +44,19 @@
   become: true
   become_user: "{{ tiaas_user }}"
   pip:
-    requirements: "{{ tiaas_dir }}/code/requirements.txt"
+    requirements: "{{ tiaas_code_dir }}/requirements.txt"
     extra_args: "--index-url https://wheels.galaxyproject.org/simple/ --extra-index-url https://pypi.python.org/simple {{ pip_extra_args | default('') }}"
-    virtualenv: "{{ tiaas_dir }}/venv/"
+    virtualenv: "{{ tiaas_venv_dir }}/"
     virtualenv_command: "{{ tiaas_virtualenv_command | default(galaxy_virtualenv_command | default(pip_virtualenv_command | default(omit))) }}"
     virtualenv_python: "{{ tiaas_virtualenv_python | default('python3') }}"
   environment:
     PYTHONPATH: null
-    VIRTUAL_ENV: "{{ tiaas_dir }}/venv/"
+    VIRTUAL_ENV: "{{ tiaas_venv_dir }}/"
   notify: 'reload tiaas'
 
 - name: Ensure config directory is available
   file:
-    path: "{{ tiaas_dir }}/config/"
+    path: "{{ tiaas_config_dir }}/"
     state: directory
     owner: "{{ tiaas_user }}"
     group: "{{ tiaas_group }}"
@@ -65,7 +65,7 @@
 - name: Send config
   template:
     src: "config.py"
-    dest: "{{ tiaas_dir }}/config/local_settings.py"
+    dest: "{{ tiaas_config_dir }}/local_settings.py"
     owner: "{{ tiaas_user }}"
     group: "{{ tiaas_group }}"
     mode: 0640
@@ -74,7 +74,7 @@
 - name: Create symlink to Galaxy's stylesheet
   file:
     src: "{{ tiaas_galaxy_stylesheet }}"
-    path: "{{ tiaas_dir }}/code/training/static/training/style/galaxy.css"
+    path: "{{ tiaas_code_dir }}/training/static/training/style/galaxy.css"
     state: link
     force: yes
 
@@ -90,9 +90,9 @@
   become_user: "{{ tiaas_user }}"
   django_manage:
     command: migrate
-    app_path: "{{ tiaas_dir }}/code/"
+    app_path: "{{ tiaas_code_dir }}/"
     pythonpath: "{{ tiaas_dir }}"
-    virtualenv: "{{ tiaas_dir }}/venv/"
+    virtualenv: "{{ tiaas_venv_dir }}/"
   when: __tiaas_git_update_result is changed
 
 # Create an initial superuser.
@@ -102,14 +102,14 @@
   django_manage:
     command: |
         shell -c "from django.contrib.auth.models import User; User.objects.create_superuser('{{ tiaas_admin_user }}', 'admin@localhost', '{{ tiaas_admin_pass }}')"
-    app_path: "{{ tiaas_dir }}/code/"
+    app_path: "{{ tiaas_code_dir }}/"
     pythonpath: "{{ tiaas_dir }}"
-    virtualenv: "{{ tiaas_dir }}/venv/"
+    virtualenv: "{{ tiaas_venv_dir }}/"
   ignore_errors: yes
 
 - name: Ensure static directory is available
   file:
-    path: "{{ tiaas_dir }}/static/"
+    path: "{{ tiaas_static_dir }}/"
     state: directory
     owner: "{{ tiaas_user }}"
     group: "{{ tiaas_group }}"
@@ -120,7 +120,7 @@
   become_user: "{{ tiaas_user }}"
   django_manage:
     command: collectstatic
-    app_path: "{{ tiaas_dir }}/code/"
+    app_path: "{{ tiaas_code_dir }}/"
     pythonpath: "{{ tiaas_dir }}"
-    virtualenv: "{{ tiaas_dir }}/venv/"
+    virtualenv: "{{ tiaas_venv_dir }}/"
   when: __tiaas_git_update_result is changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,6 +71,13 @@
     mode: 0640
   notify: 'reload tiaas'
 
+- name: Create symlink to Galaxy's stylesheet
+  file:
+    src: "{{ tiaas_galaxy_stylesheet }}"
+    path: "{{ tiaas_dir }}/code/training/static/training/style/galaxy.css"
+    state: link
+    force: yes
+
 - name: Install systemd unit file
   template:
     src: tiaas.service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,11 +71,10 @@
     mode: 0640
   notify: 'reload tiaas'
 
-- name: Create symlink to Galaxy's stylesheet
-  file:
+- name: Copy Galaxy's stylesheet
+  copy:
     src: "{{ tiaas_galaxy_stylesheet }}"
-    path: "{{ tiaas_code_dir }}/training/static/training/style/galaxy.css"
-    state: link
+    dest: "{{ tiaas_code_dir }}/training/static/training/style/galaxy.css"
     force: yes
 
 - name: Install systemd unit file

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,7 @@
   become_user: "{{ tiaas_user }}"
   git:
     repo: "https://github.com/usegalaxy-eu/tiaas2"
-    dest: "{{ tiaas_dir }}/code/"
+    dest: "{{ tiaas_code_dir }}/"
     version: "{{ tiaas_version }}"
     force: "{{ tiaas_force_checkout }}"
   register: __tiaas_git_update_result
@@ -44,18 +44,18 @@
   become: true
   become_user: "{{ tiaas_user }}"
   pip:
-    requirements: "{{ tiaas_dir }}/code/requirements.txt"
+    requirements: "{{ tiaas_code_dir }}/requirements.txt"
     extra_args: "--index-url https://wheels.galaxyproject.org/simple/ --extra-index-url https://pypi.python.org/simple {{ pip_extra_args | default('') }}"
-    virtualenv: "{{ tiaas_dir }}/venv/"
+    virtualenv: "{{ tiaas_venv_dir }}/"
     virtualenv_command: "{{ tiaas_virtualenv_command | default(galaxy_virtualenv_command | default(pip_virtualenv_command | default(omit))) }}"
   environment:
     PYTHONPATH: null
-    VIRTUAL_ENV: "{{ tiaas_dir }}/venv/"
+    VIRTUAL_ENV: "{{ tiaas_venv_dir }}/"
   notify: 'reload tiaas'
 
 - name: Ensure config directory is available
   file:
-    path: "{{ tiaas_dir }}/config/"
+    path: "{{ tiaas_config_dir }}/"
     state: directory
     owner: "{{ tiaas_user }}"
     group: "{{ tiaas_group }}"
@@ -64,7 +64,7 @@
 - name: Send config
   template:
     src: "config.py"
-    dest: "{{ tiaas_dir }}/config/local_settings.py"
+    dest: "{{ tiaas_config_dir }}/local_settings.py"
     owner: "{{ tiaas_user }}"
     group: "{{ tiaas_group }}"
     mode: 0750
@@ -73,7 +73,7 @@
 - name: Create symlink to Galaxy's stylesheet
   file:
     src: "{{ tiaas_galaxy_stylesheet }}"
-    path: "{{ tiaas_dir }}/code/training/static/training/style/galaxy.css"
+    path: "{{ tiaas_code_dir }}/training/static/training/style/galaxy.css"
     state: link
     force: yes
 
@@ -89,9 +89,9 @@
   become_user: "{{ tiaas_user }}"
   django_manage:
     command: migrate
-    app_path: "{{ tiaas_dir }}/code/"
+    app_path: "{{ tiaas_code_dir }}/"
     pythonpath: "{{ tiaas_dir }}"
-    virtualenv: "{{ tiaas_dir }}/venv/"
+    virtualenv: "{{ tiaas_venv_dir }}/"
   when: __tiaas_git_update_result is changed
 
 # Create an initial superuser.
@@ -101,14 +101,14 @@
   django_manage:
     command: |
         shell -c "from django.contrib.auth.models import User; User.objects.create_superuser('{{ tiaas_admin_user }}', 'admin@localhost', '{{ tiaas_admin_pass }}')"
-    app_path: "{{ tiaas_dir }}/code/"
+    app_path: "{{ tiaas_code_dir }}/"
     pythonpath: "{{ tiaas_dir }}"
-    virtualenv: "{{ tiaas_dir }}/venv/"
+    virtualenv: "{{ tiaas_venv_dir }}/"
   ignore_errors: yes
 
 - name: Ensure static directory is available
   file:
-    path: "{{ tiaas_dir }}/static/"
+    path: "{{ tiaas_static_dir }}/"
     state: directory
     owner: "{{ tiaas_user }}"
     group: "{{ tiaas_group }}"
@@ -119,7 +119,7 @@
   become_user: "{{ tiaas_user }}"
   django_manage:
     command: collectstatic
-    app_path: "{{ tiaas_dir }}/code/"
+    app_path: "{{ tiaas_code_dir }}/"
     pythonpath: "{{ tiaas_dir }}"
-    virtualenv: "{{ tiaas_dir }}/venv/"
+    virtualenv: "{{ tiaas_venv_dir }}/"
   when: __tiaas_git_update_result is changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -122,4 +122,3 @@
     app_path: "{{ tiaas_code_dir }}/"
     pythonpath: "{{ tiaas_dir }}"
     virtualenv: "{{ tiaas_venv_dir }}/"
-  when: __tiaas_git_update_result is changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,6 +70,13 @@
     mode: 0750
   notify: 'reload tiaas'
 
+- name: Create symlink to Galaxy's stylesheet
+  file:
+    src: "{{ tiaas_galaxy_stylesheet }}"
+    path: "{{ tiaas_dir }}/code/training/static/training/style/galaxy.css"
+    state: link
+    force: yes
+
 - name: Install systemd unit file
   template:
     src: tiaas.service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -123,4 +123,3 @@
     app_path: "{{ tiaas_code_dir }}/"
     pythonpath: "{{ tiaas_dir }}"
     virtualenv: "{{ tiaas_venv_dir }}/"
-  when: __tiaas_git_update_result is changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,7 +67,7 @@
     dest: "{{ tiaas_dir }}/config/local_settings.py"
     owner: "{{ tiaas_user }}"
     group: "{{ tiaas_group }}"
-    mode: 0644
+    mode: 0640
   notify: 'reload tiaas'
 
 - name: Install systemd unit file

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,7 +67,7 @@
     dest: "{{ tiaas_dir }}/config/local_settings.py"
     owner: "{{ tiaas_user }}"
     group: "{{ tiaas_group }}"
-    mode: 0750
+    mode: 0644
   notify: 'reload tiaas'
 
 - name: Install systemd unit file

--- a/templates/config.py
+++ b/templates/config.py
@@ -39,7 +39,7 @@ DATABASES = {
 
 ALLOWED_HOSTS = ['*']
 SECRET_KEY = '{{ tiaas_secret_key }}'
-STATIC_ROOT = '{{ tiaas_dir }}/static'
+STATIC_ROOT = '{{ tiaas_static_dir }}'
 
 
 {{ tiaas_other_config }}

--- a/templates/run.sh
+++ b/templates/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-. {{ tiaas_dir }}/venv/bin/activate
+. {{ tiaas_venv_dir }}/bin/activate
 cd {{ tiaas_dir }}/code/
 export PYTHONPATH={{ tiaas_dir }}:$PYTHONPATH
 exec uwsgi --socket {{ tiaas_listen_url | default("127.0.0.1:5000") }} --module tiaas.wsgi


### PR DESCRIPTION
Symlink: I used the file module's `force` parameter to ensure the link is created even if there's a file in its place (i.e., it'll discard all local changes, which is what we need here)

`collectstatic`: see commit message. Not that it's a common case, but if it happens, this will take care of it: any time Galaxy's css changes, we simply run the playbook to update the symlink *and* the collected static file.

