### PR TITLE
Create a cron job to disassociate training roles from groups after the training ends

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,13 @@ Example Playbook
       objs: user_group_association,galaxy_group,role,group_role_association
       type: table
       privs: SELECT,INSERT
-    # Permit updating the sequences, required to insert into the above tables.
+    # Permit disassociating training roles from groups after trainings end
+    - database: galaxy
+      roles: tiaas
+      objs: group_role_association
+      type: table
+      privs: DELETE
+    # Permit updating the sequences, required to insert into the above tables
     - database: galaxy
       roles: tiaas
       objs: role_id_seq,galaxy_group_id_seq,group_role_association_id_seq,user_group_association_id_seq

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,11 @@ tiaas_repo: "https://github.com/usegalaxy-eu/tiaas2"
 tiaas_version: master
 tiaas_galaxy_stylesheet: "{{ galaxy_server_dir }}/static/style/base.css"
 
+# Create a cron job to disassociate training roles from groups after trainings have expired, set to `false` to disable
+tiaas_disassociate_training_roles:
+  hour: 0      # optional, defaults to 0
+  minute: 0    # optional, defaults to 0
+
 # Galaxy DB access
 tiaas_galaxy_db_name: "galaxy"
 tiaas_galaxy_db_user: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -102,7 +102,7 @@
     app_path: "{{ tiaas_code_dir }}/"
     pythonpath: "{{ tiaas_dir }}"
     virtualenv: "{{ tiaas_venv_dir }}"
-  run_once: "not {{ tiaas_tiaas_use_sqlite }}"
+  run_once: "{{ not tiaas_tiaas_use_sqlite }}"
   when: __tiaas_git_update_result is changed
 
 # Create an initial superuser.
@@ -116,7 +116,7 @@
     app_path: "{{ tiaas_code_dir }}/"
     pythonpath: "{{ tiaas_dir }}"
     virtualenv: "{{ tiaas_venv_dir }}"
-  run_once: "not {{ tiaas_tiaas_use_sqlite }}"
+  run_once: "{{ not tiaas_tiaas_use_sqlite }}"
   # TODO: this could probably be failed_when
   ignore_errors: true  # noqa ignore-errors
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -136,3 +136,13 @@
     app_path: "{{ tiaas_code_dir }}/"
     pythonpath: "{{ tiaas_dir }}"
     virtualenv: "{{ tiaas_venv_dir }}"
+
+- name: Schedule cron job to disassociate training groups from roles after training expires
+  cron:
+    user: "{{ tiaas_user }}"
+    cron_file: ansible_tiaas2_disassociate_training_roles
+    name: tiaas_disassociate_training_roles
+    state: "{{ (tiaas_disassociate_training_roles is truthy) | ternary('present', 'absent') }}"
+    hour: "{{ tiaas_disassociate_training_roles.hour | default(0) }}"
+    minute: "{{ tiaas_disassociate_training_roles.minute | default(0) }}"
+    job: "{ date; {{ tiaas_venv_dir }}/bin/python {{ tiaas_code_dir }}/manage.py disassociate_training_roles --pythonpath {{ tiaas_dir }}; } >> {{ tiaas_dir }}/disassociate_training_roles.log"


### PR DESCRIPTION
For the new feature added by @hexylena in usegalaxy-eu/tiaas2#21

Also fix a bug with the `run_once` stuff I previously added (not sure how I didn't have problems with it before but ok).