### PR TITLE
Fix syntax error

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -112,7 +112,7 @@
   django_manage:
     command: >-
         shell -c
-        "from django.contrib.auth.models import User; User.objects.create_superuser('{{ tiaas_admin_user }}', 'admin@localhost', '{{ tiaas_admin_pass }}') if User.objects.filter(username='{{ tiaas_admin_user }}').count() == 0"
+        "from django.contrib.auth.models import User; User.objects.create_superuser('{{ tiaas_admin_user }}', 'admin@localhost', '{{ tiaas_admin_pass }}') if User.objects.filter(username='{{ tiaas_admin_user }}').count() == 0 else None"
     app_path: "{{ tiaas_code_dir }}/"
     pythonpath: "{{ tiaas_dir }}"
     virtualenv: "{{ tiaas_venv_dir }}"


### PR DESCRIPTION
Got this error while using the latest code from master branch:
```
fatal: [192.168.xxx]: FAILED! => {"changed": false, "cmd": ["./manage.py", "shell", "-c", "from django.contrib.auth.models import User; User.objects.create_superuser('admin', 'admin@localhost', 'admin') if User.objects.filter(username='admin').count() == 0", "--pythonpath=/xxx/galaxy/tiaas"], "msg": "
:stderr: Traceback (most recent call last):
  File \"./manage.py\", line 21, in <module>
    main()
  File \"./manage.py\", line 17, in main
    execute_from_command_line(sys.argv)
  File \"/xxx/galaxy/tiaas/venv/lib/python3.6/site-packages/django/core/management/__init__.py\", line 401, in execute_from_command_line
    utility.execute()
  File \"/xxx/galaxy/tiaas/venv/lib/python3.6/site-packages/django/core/management/__init__.py\", line 395, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File \"/xxx/galaxy/tiaas/venv/lib/python3.6/site-packages/django/core/management/base.py\", line 330, in run_from_argv
    self.execute(*args, **cmd_options)
  File \"/xxx/galaxy/tiaas/venv/lib/python3.6/site-packages/django/core/management/base.py\", line 371, in execute
    output = self.handle(*args, **options)
  File \"/xxx/galaxy/tiaas/venv/lib/python3.6/site-packages/django/core/management/commands/shell.py\", line 87, in handle
    exec(options['command'])
  File \"<string>\", line 1
    from django.contrib.auth.models import User; User.objects.create_superuser('admin', 'admin@localhost', 'admin') if User.objects.filter(username='admin').count() == 0
                                                                                                                                                                        ^
SyntaxError: invalid syntax
```

So here's (hopefully) a fix for this